### PR TITLE
Add map with image comparison slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flashback Maps</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/leaflet-rotatedmarker@0.2.0/leaflet.rotatedMarker.js"></script>
+</head>
+<body>
+  <div id="map"></div>
+
+  <div id="slider-container" class="hidden">
+    <div class="slider-wrapper">
+      <span id="close-btn">&times;</span>
+      <div class="img-container">
+        <img src="" id="img-new" />
+        <div id="img-overlay">
+          <img src="" id="img-old" />
+        </div>
+      </div>
+      <input type="range" id="slider" min="0" max="100" value="50" />
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,36 @@
+const map = L.map('map').setView([50.4501, 30.5234], 13);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+const points = [
+  {
+    coords: [50.4501, 30.5234],
+    angle: 45,
+    oldImg: 'https://via.placeholder.com/400x300.png?text=Old',
+    newImg: 'https://via.placeholder.com/400x300.png?text=New'
+  }
+];
+
+points.forEach(pt => {
+  const marker = L.marker(pt.coords, { rotationAngle: pt.angle }).addTo(map);
+  marker.on('click', () => openSlider(pt.oldImg, pt.newImg));
+});
+
+function openSlider(oldSrc, newSrc) {
+  const overlay = document.getElementById('slider-container');
+  overlay.classList.remove('hidden');
+  document.getElementById('img-old').src = oldSrc;
+  document.getElementById('img-new').src = newSrc;
+  document.getElementById('img-overlay').style.width = '50%';
+  document.getElementById('slider').value = 50;
+}
+
+document.getElementById('close-btn').onclick = () => {
+  document.getElementById('slider-container').classList.add('hidden');
+};
+
+const slider = document.getElementById('slider');
+slider.addEventListener('input', (e) => {
+  document.getElementById('img-overlay').style.width = `${e.target.value}%`;
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,53 @@
+html, body, #map {
+  height: 100%;
+  margin: 0;
+}
+#map {
+  width: 100%;
+}
+#slider-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#slider-container.hidden {
+  display: none;
+}
+.slider-wrapper {
+  position: relative;
+  background: #fff;
+  padding: 10px;
+}
+.img-container {
+  position: relative;
+  width: 400px;
+  max-width: 90vw;
+  overflow: hidden;
+}
+.img-container img {
+  display: block;
+  width: 100%;
+}
+#img-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50%;
+  overflow: hidden;
+}
+#close-btn {
+  position: absolute;
+  top: 5px;
+  right: 10px;
+  cursor: pointer;
+  font-size: 24px;
+}
+#slider {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- create Leaflet map setup with oriented markers
- open modal slider to compare historical and modern photos

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6899e06d191c83339437bba1c86e4149